### PR TITLE
feat: add terraform stack for code execution environment

### DIFF
--- a/CODE_EXECUTION_ENVIRONMENT_SPEC.md
+++ b/CODE_EXECUTION_ENVIRONMENT_SPEC.md
@@ -1,0 +1,147 @@
+# LibreChat Code Execution Environment Specification
+
+This document describes the API contract and runtime requirements for a code execution service that is fully
+compatible with [LibreChat](https://librechat.ai)'s **Run Code** tool.
+It also explains how the code execution "sessions" are tied to a chat discussion in LibreChat's database and
+how input/output files—images, CSVs, audio, etc.—are handled and rendered.
+
+## 1. Architecture Overview
+
+LibreChat communicates with a remote sandbox via a REST API.  Each execution takes place in an isolated
+environment identified by a `session_id`.  The `session_id` links all file operations for a chat message and is
+stored in the message's metadata inside the conversation record.  Files created in a session may be attached to
+messages and referenced in later runs.
+
+```
+User message ──► LibreChat ──► Code Execution API ──► sandbox
+                                     ▲
+                                     └── files & stdout/stderr
+```
+
+### Working directory
+
+* Runtime starts in `/mnt/data` with read‑only base filesystem.
+* Programs may create new files anywhere under `/mnt/data`.
+* Outbound network access **must be disabled**.
+* Resource limits (CPU, RAM, wall‑clock) must be enforced per run.
+
+## 2. API Contract
+
+All endpoints require header `X-API-Key` with a token issued by the sandbox service.  LibreChat provides the
+value through `LIBRECHAT_CODE_API_KEY` or a user‑supplied key.  The base URL defaults to
+`https://code.librechat.ai` but can be overridden with `LIBRECHAT_CODE_BASEURL`.
+
+### 2.1 `POST /exec`
+Run code within the sandbox.
+
+**Request body**
+```json
+{
+  "lang": "py",                  // one of: py, js, ts, c, cpp, java, php, rs, go, d, f90, r
+  "code": "print('hi')",          // user code
+  "args": "--flag",              // optional runtime args
+  "session_id": "<id>",          // optional existing session to reuse uploaded files
+  "files": [ {"id":"<fileId>", "name": "input.txt"} ] // optional previously uploaded files
+}
+```
+
+**Response body**
+```json
+{
+  "stdout": "hello\n",
+  "stderr": "",
+  "session_id": "<id>",
+  "files": [ {"name":"plot.png","size":24567} ]
+}
+```
+* `session_id` is newly created when omitted in the request.
+* `files` lists artifacts generated during execution located under `/mnt/data`.
+
+### 2.2 `POST /upload`
+Upload a user file so that subsequent executions can consume it.
+
+* Content type: `multipart/form-data`
+* Fields:
+  * `file` – binary payload.
+  * `entity_id` – optional identifier to associate the upload with an existing message.
+* Response:
+```json
+{
+  "message": "success",
+  "session_id": "<id>",
+  "files": [ {"fileId":"<fid>", "filename":"data.csv"} ]
+}
+```
+* LibreChat records `session_id/fileId` as the file identifier in message attachments.
+
+### 2.3 `GET /files/{session_id}`
+List files for a session.  Optional query `detail=full|summary`.
+The result informs LibreChat of existing artifacts when resuming a session.
+
+### 2.4 `GET /download/{session_id}/{fileId}`
+Download an artifact as binary.  LibreChat proxies this through its own `/api/files/code/download/...` route so
+that files can be served to the client or persisted in its own storage.
+
+## 3. Session ↔ Conversation linkage
+
+1. When a user invokes the **Run Code** tool, the returned `session_id` is stored with the assistant message in
+   LibreChat's database (e.g. `message.code_session_id`).
+2. Output files are processed via the server's `processCodeOutput` routine which:
+   * Converts image outputs to the configured format and saves them to the main file store so that they persist
+     beyond the sandbox's 24‑hour TTL.
+   * Records file metadata (`file_id`, `filename`, `session_id/fileId`) on the message document.
+   * Non‑image files are left in the sandbox and referenced through the `/api/files/code/download/...` proxy.
+3. On subsequent executions in the same conversation, LibreChat re‑uploads previous attachments (if the sandbox
+   has expired) and passes the resulting `session_id/fileId` pairs in the `files` array so the runtime can access
+   them.
+
+Sessions should be garbage‑collected roughly 24 hours after creation.  Conversations will continue to hold
+references, but downloading a file after expiry will fail.
+
+## 4. File handling and rendering
+
+LibreChat inspects file extensions to decide how to present results:
+
+| Type            | Behaviour in UI |
+|-----------------|-----------------|
+| Images (`.png`, `.jpg`, etc.) | Displayed inline within the chat; also persisted to LibreChat's own file store for permanent access. |
+| CSV / TSV       | Previewed as an interactive table with option to download the raw file. |
+| JSON / text     | Rendered in a code block; download link provided. |
+| PDFs            | Shown via in‑browser viewer where supported, otherwise offered as download. |
+| Audio (`.mp3`, `.wav`, …) | Embedded `<audio>` player allows immediate playback.  LibreChat may also offer to attach the audio as input to subsequent model calls if the selected model accepts audio. |
+| Other binaries  | Download link only. |
+
+Uploaded input files follow the same detection logic so users can preview what was supplied to the sandbox.
+
+## 5. Extended media capabilities
+
+The code environment can generate diverse media types.  LibreChat can optionally
+utilize them beyond simple download links:
+
+* **Images** – Used as inline chat content or as references for vision‑capable models.
+* **Audio** – When the active model supports audio input, LibreChat may suggest using generated audio as a
+  follow‑up prompt attachment.  Otherwise the user can simply play the file.
+* **Data files (CSV, XLSX)** – Can be offered as context to later prompts or opened in a built‑in preview.
+* **Arbitrary binaries** – Users can download and manage them manually.
+
+## 6. Security & Isolation
+
+* Sandbox must run each `exec` call in a fresh process or container.
+* Disallow outbound networking and limit inbound traffic to the API layer.
+* Enforce per‑run limits (CPU, RAM, file system quota, execution time) to prevent abuse.
+* Clean up processes and temporary files after execution or session expiry.
+
+## 7. Lifecycle of a typical run
+
+1. User writes a message and activates **Run Code**.
+2. LibreChat uploads any user‑supplied files (`POST /upload`).
+3. LibreChat calls `POST /exec` with code, referencing uploaded files and the current `session_id` if any.
+4. Sandbox executes and returns `stdout`, `stderr`, and file metadata.
+5. LibreChat stores the `session_id` and persists any image outputs; other files remain in the sandbox and can be
+   downloaded through LibreChat's proxy.
+6. The assistant message displays `stdout` plus rendered attachments.
+7. Subsequent runs in the same conversation reuse the `session_id` so previous files remain available.
+
+---
+A service implementing the above interface and behaviour can replace LibreChat's hosted code execution API,
+allowing self‑hosted or custom sandboxes to integrate seamlessly.

--- a/codeexecution/README.md
+++ b/codeexecution/README.md
@@ -1,0 +1,28 @@
+# Code Execution Terraform Stack
+
+This module provisions an AWS-based sandbox compatible with LibreChat's code execution feature. It creates:
+
+- **API Lambda** – Node.js function exposing REST endpoints and managing sessions
+- **Python Executor Lambda** – isolated function invoked by the API Lambda to run user Python code
+- **EFS File System** – mounted at `/mnt/data` on the API Lambda, providing per-session persistence
+- **API Gateway** – REST API forwarding `/exec` calls to the API Lambda
+- **IAM Roles/Policies** – permissions for invoking the executor, writing to EFS, VPC access, and API Gateway integration
+
+## Usage
+
+1. Provide values for required variables in a `terraform.tfvars` or via CLI:
+   - `region`
+   - `vpc_id`
+   - `subnet_ids`
+   - optional paths for `api_lambda_zip` and `python_lambda_zip`
+2. Initialize and validate:
+   ```bash
+   terraform init -backend=false
+   terraform validate
+   ```
+3. Deploy:
+   ```bash
+   terraform apply
+   ```
+
+The output `api_gateway_url` exposes the endpoint that LibreChat should target as the `LIBRECHAT_CODE_BASEURL`.

--- a/codeexecution/main.tf
+++ b/codeexecution/main.tf
@@ -1,0 +1,213 @@
+provider "aws" {
+  region = var.region
+}
+
+# Security group for Lambda function
+resource "aws_security_group" "lambda" {
+  name   = "code-execution-lambda"
+  vpc_id = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Security group for EFS allowing NFS from Lambda
+resource "aws_security_group" "lambda_efs" {
+  name   = "code-execution-efs"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# EFS file system used for session persistence
+resource "aws_efs_file_system" "code" {
+  creation_token = "librechat-code-execution"
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+}
+
+resource "aws_efs_mount_target" "code" {
+  count          = length(var.subnet_ids)
+  file_system_id = aws_efs_file_system.code.id
+  subnet_id      = var.subnet_ids[count.index]
+  security_groups = [aws_security_group.lambda_efs.id]
+}
+
+resource "aws_efs_access_point" "code" {
+  file_system_id = aws_efs_file_system.code.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "750"
+    }
+  }
+}
+
+# IAM Roles
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "api_lambda" {
+  name               = "code-execution-api"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role" "python_lambda" {
+  name               = "code-execution-python"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_policy" "efs_and_invoke" {
+  name   = "code-execution-efs-invoke"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = ["elasticfilesystem:ClientMount", "elasticfilesystem:ClientWrite", "elasticfilesystem:ClientRootAccess"],
+        Resource = [aws_efs_file_system.code.arn, aws_efs_access_point.code.arn]
+      },
+      {
+        Effect   = "Allow",
+        Action   = ["lambda:InvokeFunction"],
+        Resource = aws_lambda_function.python.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "api_basic" {
+  role       = aws_iam_role.api_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "api_vpc" {
+  role       = aws_iam_role.api_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "api_custom" {
+  role       = aws_iam_role.api_lambda.name
+  policy_arn = aws_iam_policy.efs_and_invoke.arn
+}
+
+resource "aws_iam_role_policy_attachment" "python_basic" {
+  role       = aws_iam_role.python_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Python execution Lambda
+resource "aws_lambda_function" "python" {
+  function_name = "code-execution-python"
+  role          = aws_iam_role.python_lambda.arn
+  handler       = "handler.run"
+  runtime       = "python3.11"
+  filename      = var.python_lambda_zip
+  source_code_hash = filebase64sha256(var.python_lambda_zip)
+}
+
+# API Lambda exposing REST interface
+resource "aws_lambda_function" "api" {
+  function_name = "code-execution-api"
+  role          = aws_iam_role.api_lambda.arn
+  handler       = "index.handler"
+  runtime       = "nodejs18.x"
+  filename      = var.api_lambda_zip
+  source_code_hash = filebase64sha256(var.api_lambda_zip)
+
+  vpc_config {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
+  file_system_config {
+    arn              = aws_efs_access_point.code.arn
+    local_mount_path = "/mnt/data"
+  }
+
+  environment {
+    variables = {
+      PYTHON_LAMBDA_ARN = aws_lambda_function.python.arn
+    }
+  }
+}
+
+# API Gateway setup
+resource "aws_api_gateway_rest_api" "code_execution" {
+  name = "code-execution-api"
+}
+
+resource "aws_api_gateway_resource" "exec" {
+  rest_api_id = aws_api_gateway_rest_api.code_execution.id
+  parent_id   = aws_api_gateway_rest_api.code_execution.root_resource_id
+  path_part   = "exec"
+}
+
+resource "aws_api_gateway_method" "exec_post" {
+  rest_api_id   = aws_api_gateway_rest_api.code_execution.id
+  resource_id   = aws_api_gateway_resource.exec.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "exec_lambda" {
+  rest_api_id             = aws_api_gateway_rest_api.code_execution.id
+  resource_id             = aws_api_gateway_resource.exec.id
+  http_method             = aws_api_gateway_method.exec_post.http_method
+  integration_http_method = "POST"
+  type                   = "AWS_PROXY"
+  uri                    = aws_lambda_function.api.invoke_arn
+}
+
+resource "aws_lambda_permission" "allow_apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.code_execution.execution_arn}/*/*"
+}
+
+resource "aws_api_gateway_deployment" "code_execution" {
+  depends_on = [aws_api_gateway_integration.exec_lambda]
+  rest_api_id = aws_api_gateway_rest_api.code_execution.id
+}
+
+resource "aws_api_gateway_stage" "prod" {
+  rest_api_id   = aws_api_gateway_rest_api.code_execution.id
+  deployment_id = aws_api_gateway_deployment.code_execution.id
+  stage_name    = "prod"
+}

--- a/codeexecution/outputs.tf
+++ b/codeexecution/outputs.tf
@@ -1,0 +1,19 @@
+output "api_gateway_url" {
+  description = "Invoke URL for the code execution API"
+  value       = aws_api_gateway_stage.prod.invoke_url
+}
+
+output "efs_id" {
+  description = "ID of the EFS file system"
+  value       = aws_efs_file_system.code.id
+}
+
+output "api_lambda_arn" {
+  description = "ARN of the API Lambda"
+  value       = aws_lambda_function.api.arn
+}
+
+output "python_lambda_arn" {
+  description = "ARN of the Python execution Lambda"
+  value       = aws_lambda_function.python.arn
+}

--- a/codeexecution/variables.tf
+++ b/codeexecution/variables.tf
@@ -1,0 +1,26 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC where Lambda and EFS reside"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets for Lambda and EFS mount targets"
+  type        = list(string)
+}
+
+variable "api_lambda_zip" {
+  description = "Path to deployment package for the API Lambda"
+  type        = string
+  default     = "api.zip"
+}
+
+variable "python_lambda_zip" {
+  description = "Path to deployment package for the Python executor Lambda"
+  type        = string
+  default     = "python.zip"
+}


### PR DESCRIPTION
## Summary
- add Terraform infrastructure for self-hosted code execution service
- provision API and Python Lambda functions with shared EFS session storage
- expose `/exec` endpoint through API Gateway and required IAM roles

## Testing
- `npm test` *(fails: Missing script)*
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ca425d74833295cc16cac6d4c859